### PR TITLE
doc(wireframe): add initial screen proposal

### DIFF
--- a/plan/creating-path.wt
+++ b/plan/creating-path.wt
@@ -1,0 +1,17 @@
+include components-v1
+
+Computer id=wintest title="mentorIA" notes="""
+The name of the last-opened file is stored, and if the file still exists when the application starts again, it should automatically be opened.
+"""
+	MenuBar
+		MenuCategory category="Paths"
+			Button icon=new content="Create"
+			Button icon=file content="Load"
+			Button icon=close content=Exit
+		MenuCategory category="Help"
+	Popup
+		TextArea label="Theme" value="""
+		Japanese JLPT1"""
+		.wt-columns
+			Button content="Create"
+			Button content="Cancel"

--- a/plan/initial-screen.wt
+++ b/plan/initial-screen.wt
@@ -1,0 +1,12 @@
+include components-v1
+
+Computer id=wintest title="mentorIA" notes="""
+The name of the last-opened file is stored, and if the file still exists when the application starts again, it should automatically be opened.
+"""
+	MenuBar
+		MenuCategory category="Paths"
+			Button icon=new content="Create"
+			Button icon=file content="Load"
+			Button icon=close content=Exit
+		MenuCategory category="Help"
+	.wt-empty-page "Start by creating a new path..."


### PR DESCRIPTION
# Add initial screen proposal

## Description

This pull request introduces initial wireframe screens for the "mentorIA" platform. The focus of this PR is to draft some screens as wireframes, providing a visual structure for the application's interface.

### Changes
1. **Initial Screen (plan/initial-scree.wt):**
   - Included components-v1.
   - Added a `Computer` element with the title "mentorIA" and a note describing the auto-opening of the last-opened file.
   - Created a `MenuBar` with categories "Paths" and "Help".
   - Added `Button` elements for "Create", "Load", and "Exit" under the "Paths" category.
   - Added an empty page placeholder with the text "Start by creating a new path...".

2. **Creating Path Screen (plan/creating-path.wt):**
   - Included components-v1.
   - Added a `Computer` element with the title "mentorIA" and a note describing the auto-opening of the last-opened file.
   - Created a `MenuBar` with categories "Paths" and "Help".
   - Added a `Popup` element with a `TextArea` for the "Theme" and `Button` elements for "Create" and "Cancel".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Visual inspection of the wireframes in WireText.
- [ ] Peer review of the code and structure.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable):

![image](https://github.com/user-attachments/assets/28bce1e7-25fb-4295-8504-7bfdbacf8f20)
![image](https://github.com/user-attachments/assets/df451e51-dba9-4633-b4a4-e40fb1c0e2a4)

